### PR TITLE
Add get_user_info method

### DIFF
--- a/ndp_ep/__init__.py
+++ b/ndp_ep/__init__.py
@@ -12,6 +12,7 @@ from .delete_organization_method import APIClientOrganizationDelete
 from .delete_resource_method import APIClientResourceDelete
 from .get_kafka_details_method import APIClientKafkaDetails
 from .get_system_status_method import APIClientSystemStatus
+from .get_user_info_method import APIClientUserInfo
 from .list_organization_method import APIClientOrganizationList
 from .register_dataset_method import APIClientDatasetRegister
 from .register_kafka_method import APIClientKafkaRegister

--- a/ndp_ep/api_client.py
+++ b/ndp_ep/api_client.py
@@ -4,6 +4,7 @@ from .delete_organization_method import APIClientOrganizationDelete
 from .delete_resource_method import APIClientResourceDelete
 from .get_kafka_details_method import APIClientKafkaDetails
 from .get_system_status_method import APIClientSystemStatus
+from .get_user_info_method import APIClientUserInfo
 from .list_organization_method import APIClientOrganizationList
 from .register_dataset_method import APIClientDatasetRegister
 from .register_kafka_method import APIClientKafkaRegister
@@ -37,6 +38,7 @@ class APIClient(
     APIClientResourceDelete,
     APIClientKafkaDetails,
     APIClientSystemStatus,
+    APIClientUserInfo,
     APIClientS3Buckets,
     APIClientS3Objects,
 ):
@@ -53,6 +55,7 @@ class APIClient(
     - Resource deletion (by ID and name)
     - Search functionality (simple and advanced)
     - System information (status, metrics, Kafka details, Jupyter details)
+    - User information (get current authenticated user details)
     - S3 buckets management (create, list, delete, get info)
     - S3 objects management (upload, download, delete, list, metadata, presigned URLs)
     - Authentication (token-based and username/password)

--- a/ndp_ep/get_user_info_method.py
+++ b/ndp_ep/get_user_info_method.py
@@ -1,0 +1,70 @@
+"""User information retrieval functionality."""
+
+from typing import Any, Dict
+
+import requests
+
+from .client_base import APIClientBase
+
+
+class APIClientUserInfo(APIClientBase):
+    """A class to handle requests for user information."""
+
+    def get_user_info(self) -> Dict[str, Any]:
+        """
+        Get current user information.
+
+        Retrieve detailed information about the currently authenticated user
+        from the authentication service. This endpoint requires a valid
+        Bearer token.
+
+        Returns:
+            User information including roles, groups, username, email, etc.
+
+        Raises:
+            ValueError: If the API response contains an error, token is
+                invalid, or the service is unreachable.
+
+        Example:
+            >>> client = APIClient(base_url="https://api.example.com",
+            ...                    token="your-token")
+            >>> user = client.get_user_info()
+            >>> print(user["username"])
+            'john.doe'
+        """
+        endpoint = f"{self.base_url}/user/info"
+        try:
+            response = self.session.get(endpoint)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.HTTPError as http_err:
+            error_detail = ""
+            try:
+                error_json = http_err.response.json()
+                error_detail = error_json.get("detail", "")
+            except (ValueError, AttributeError):
+                pass
+
+            if http_err.response.status_code == 401:
+                msg = error_detail or "Invalid or missing token"
+                raise ValueError(f"Not authenticated: {msg}") from http_err
+            elif http_err.response.status_code == 403:
+                raise ValueError(
+                    f"Forbidden: {error_detail or 'Insufficient permissions'}"
+                ) from http_err
+            elif http_err.response.status_code == 502:
+                raise ValueError(
+                    f"Authentication service unavailable: {error_detail}"
+                ) from http_err
+            else:
+                raise ValueError(
+                    f"Failed to fetch user info: {http_err}"
+                ) from http_err
+        except requests.exceptions.RequestException as req_err:
+            raise ValueError(
+                f"An error occurred while fetching user info: {req_err}"
+            ) from req_err
+        except ValueError as json_err:
+            raise ValueError(
+                f"An error occurred while parsing user info: {json_err}"
+            ) from json_err

--- a/tests/test_user_info_method.py
+++ b/tests/test_user_info_method.py
@@ -1,0 +1,108 @@
+"""Tests for user info method."""
+
+import pytest
+import requests_mock
+
+from ndp_ep.get_user_info_method import APIClientUserInfo
+
+
+class TestUserInfoMethod:
+    """Test user information retrieval methods."""
+
+    @pytest.fixture
+    def user_info_client(self):
+        """Create user info client."""
+        with requests_mock.Mocker() as m:
+            m.get("http://example.com", status_code=200)
+            return APIClientUserInfo(base_url="http://example.com")
+
+    def test_get_user_info_success(self, user_info_client):
+        """Test successful user info retrieval."""
+        expected_info = {
+            "roles": ["admin", "user"],
+            "groups": ["University Research Group", "researchers"],
+            "sub": "user123",
+            "username": "john.doe",
+            "email": "john.doe@university.edu",
+        }
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                "http://example.com/user/info",
+                json=expected_info,
+                status_code=200,
+            )
+
+            result = user_info_client.get_user_info()
+            assert result == expected_info
+            assert result["username"] == "john.doe"
+            assert "admin" in result["roles"]
+
+    def test_get_user_info_unauthorized(self, user_info_client):
+        """Test user info retrieval with invalid token."""
+        with requests_mock.Mocker() as m:
+            m.get(
+                "http://example.com/user/info",
+                json={"detail": "Invalid or expired token"},
+                status_code=401,
+            )
+
+            with pytest.raises(ValueError, match="Not authenticated"):
+                user_info_client.get_user_info()
+
+    def test_get_user_info_forbidden(self, user_info_client):
+        """Test user info retrieval with insufficient permissions."""
+        with requests_mock.Mocker() as m:
+            m.get(
+                "http://example.com/user/info",
+                json={"detail": "Token does not have sufficient permissions"},
+                status_code=403,
+            )
+
+            with pytest.raises(ValueError, match="Forbidden"):
+                user_info_client.get_user_info()
+
+    def test_get_user_info_service_unavailable(self, user_info_client):
+        """Test user info retrieval when auth service is unavailable."""
+        with requests_mock.Mocker() as m:
+            m.get(
+                "http://example.com/user/info",
+                json={"detail": "Authentication service is unavailable"},
+                status_code=502,
+            )
+
+            with pytest.raises(
+                ValueError, match="Authentication service unavailable"
+            ):
+                user_info_client.get_user_info()
+
+    def test_get_user_info_generic_error(self, user_info_client):
+        """Test user info retrieval with generic HTTP error."""
+        with requests_mock.Mocker() as m:
+            m.get(
+                "http://example.com/user/info",
+                json={"detail": "Internal server error"},
+                status_code=500,
+            )
+
+            with pytest.raises(ValueError, match="Failed to fetch user info"):
+                user_info_client.get_user_info()
+
+    def test_get_user_info_minimal_response(self, user_info_client):
+        """Test user info with minimal response data."""
+        expected_info = {
+            "sub": "user456",
+            "username": "minimal.user",
+        }
+
+        with requests_mock.Mocker() as m:
+            m.get(
+                "http://example.com/user/info",
+                json=expected_info,
+                status_code=200,
+            )
+
+            result = user_info_client.get_user_info()
+            assert result == expected_info
+            assert "roles" not in result
+            assert "email" not in result


### PR DESCRIPTION
## Summary
- Add `get_user_info()` method to retrieve authenticated user details from `GET /user/info`
- Handle specific HTTP errors (401, 403, 502) with descriptive messages
- Add comprehensive test coverage

## Test plan
- [x] Unit tests pass (6 new tests)
- [x] All existing tests pass (137 total)
- [x] flake8, mypy, black checks pass
- [x] Coverage at 89%

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)