### PR TITLE
Add patch_s3_resource method for partial S3 updates

### DIFF
--- a/ndp_ep/update_s3_method.py
+++ b/ndp_ep/update_s3_method.py
@@ -49,3 +49,56 @@ class APIClientS3Update(APIClientBase):
                 raise ValueError("Error updating S3 resource: Not found")
             else:
                 raise ValueError(f"Error updating S3 resource: {error_detail}")
+
+    def patch_s3_resource(
+        self, resource_id: str, data: Dict[str, Any], server: str = "local"
+    ) -> Dict[str, Any]:
+        """
+        Partially update an existing S3 resource by making a PATCH request.
+
+        Only updates the fields provided in data, leaving other fields
+        unchanged. This is useful when you only want to modify specific
+        attributes without affecting the rest of the S3 resource.
+
+        Args:
+            resource_id: ID of the resource to update.
+            data: Partial data for updating the S3 resource. Can contain:
+                - resource_name: Optional unique name of the resource
+                - resource_title: Optional title of the resource
+                - owner_org: Optional ID of the organization
+                - resource_s3: Optional S3 URL of the resource
+                - notes: Optional additional notes
+                - extras: Optional additional metadata (merged with existing)
+            server: Specify 'local' or 'pre_ckan'. Defaults to 'local'.
+
+        Returns:
+            Response JSON data indicating success.
+
+        Raises:
+            ValueError: If the update fails.
+
+        Example:
+            >>> client.patch_s3_resource(
+            ...     "resource-id-123",
+            ...     {"resource_title": "Updated Title"}
+            ... )
+            {'message': 'S3 resource updated successfully'}
+        """
+        url = f"{self.base_url}/s3/{resource_id}"
+        params = {"server": server}
+        try:
+            response = self.session.patch(url, json=data, params=params)
+            response.raise_for_status()
+            return response.json()
+        except HTTPError as e:
+            try:
+                error_detail = response.json().get("detail", str(e))
+            except Exception:
+                error_detail = str(e)
+
+            if "not found" in error_detail.lower():
+                raise ValueError("Error updating S3 resource: Not found")
+            elif "Reserved key" in error_detail:
+                raise ValueError(f"Error updating S3 resource: {error_detail}")
+            else:
+                raise ValueError(f"Error updating S3 resource: {error_detail}")

--- a/tests/test_additional_methods.py
+++ b/tests/test_additional_methods.py
@@ -172,6 +172,48 @@ class TestUpdateMethods:
             result = update_s3_client.update_s3_resource("s3123", update_data)
             assert "updated successfully" in result["message"]
 
+    def test_patch_s3_resource_success(self, update_s3_client):
+        """Test successful S3 resource partial update."""
+        patch_data = {"resource_title": "Partially Updated Title"}
+
+        with requests_mock.Mocker() as m:
+            m.patch(
+                "http://example.com/s3/s3123",
+                json={"message": "S3 resource updated successfully"},
+                status_code=200,
+            )
+
+            result = update_s3_client.patch_s3_resource("s3123", patch_data)
+            assert "updated successfully" in result["message"]
+
+    def test_patch_s3_resource_not_found(self, update_s3_client):
+        """Test S3 resource partial update when not found."""
+        patch_data = {"resource_title": "New Title"}
+
+        with requests_mock.Mocker() as m:
+            m.patch(
+                "http://example.com/s3/nonexistent",
+                json={"detail": "S3 resource not found"},
+                status_code=404,
+            )
+
+            with pytest.raises(ValueError, match="Not found"):
+                update_s3_client.patch_s3_resource("nonexistent", patch_data)
+
+    def test_patch_s3_resource_reserved_key(self, update_s3_client):
+        """Test S3 resource partial update with reserved key error."""
+        patch_data = {"extras": {"id": "reserved"}}
+
+        with requests_mock.Mocker() as m:
+            m.patch(
+                "http://example.com/s3/s3123",
+                json={"detail": "Reserved key error: id"},
+                status_code=400,
+            )
+
+            with pytest.raises(ValueError, match="Reserved key"):
+                update_s3_client.patch_s3_resource("s3123", patch_data)
+
     def test_update_url_resource_success(self, update_url_client):
         """Test successful URL resource update."""
         update_data = {"resource_title": "Updated URL Title"}


### PR DESCRIPTION
## Summary
- Add `patch_s3_resource()` method for partial updates via `PATCH /s3/{resource_id}`
- Only updates provided fields, leaving others unchanged
- Handle not found and reserved key errors appropriately

## Test plan
- [x] Unit tests pass (3 new tests)
- [x] All existing tests pass (140 total)
- [x] flake8, mypy checks pass
- [x] Coverage at 88%

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)