### PR TITLE
Add update_service and patch_service methods

### DIFF
--- a/ndp_ep/__init__.py
+++ b/ndp_ep/__init__.py
@@ -24,6 +24,7 @@ from .search_method import APIClientSearch
 from .update_dataset_method import APIClientDatasetUpdate
 from .update_kafka_method import APIClientKafkaUpdate
 from .update_s3_method import APIClientS3Update
+from .update_service_method import APIClientServiceUpdate
 from .update_url_method import APIClientURLUpdate
 
 __version__ = "0.1.1"

--- a/ndp_ep/api_client.py
+++ b/ndp_ep/api_client.py
@@ -18,6 +18,7 @@ from .search_method import APIClientSearch
 from .update_dataset_method import APIClientDatasetUpdate
 from .update_kafka_method import APIClientKafkaUpdate
 from .update_s3_method import APIClientS3Update
+from .update_service_method import APIClientServiceUpdate
 from .update_url_method import APIClientURLUpdate
 
 
@@ -32,6 +33,7 @@ class APIClient(
     APIClientSearch,
     APIClientKafkaUpdate,
     APIClientS3Update,
+    APIClientServiceUpdate,
     APIClientURLUpdate,
     APIClientDatasetUpdate,
     APIClientOrganizationDelete,
@@ -51,7 +53,7 @@ class APIClient(
     Features:
     - Organization management (create, list, delete)
     - Resource registration (Kafka, S3, URL, Services, General datasets)
-    - Resource updates (Kafka, S3, URL, General datasets)
+    - Resource updates (Kafka, S3, URL, Services, General datasets)
     - Resource deletion (by ID and name)
     - Search functionality (simple and advanced)
     - System information (status, metrics, Kafka details, Jupyter details)

--- a/ndp_ep/update_service_method.py
+++ b/ndp_ep/update_service_method.py
@@ -1,0 +1,119 @@
+"""Service update functionality."""
+
+from typing import Any, Dict
+
+from requests.exceptions import HTTPError
+
+from .client_base import APIClientBase
+
+
+class APIClientServiceUpdate(APIClientBase):
+    """Extension of APIClientBase with service update methods."""
+
+    def update_service(
+        self, service_id: str, data: Dict[str, Any], server: str = "local"
+    ) -> Dict[str, Any]:
+        """
+        Update an existing service by making a PUT request (full replacement).
+
+        Args:
+            service_id: ID of the service to update.
+            data: Data for updating the service. Can contain:
+                - service_name: Optional unique name of the service
+                - service_title: Optional title of the service
+                - owner_org: Optional ID of the organization
+                - service_url: Optional URL where service is accessible
+                - service_type: Optional type (API, Web Service, etc.)
+                - notes: Optional additional notes
+                - extras: Optional additional metadata
+                - health_check_url: Optional health check endpoint
+                - documentation_url: Optional documentation URL
+            server: Specify 'local' or 'pre_ckan'. Defaults to 'local'.
+
+        Returns:
+            Response JSON data indicating success.
+
+        Raises:
+            ValueError: If the update fails.
+
+        Example:
+            >>> client.update_service(
+            ...     "service-id-123",
+            ...     {"service_title": "Updated API", "service_url": "https://..."}
+            ... )
+            {'message': 'Service updated successfully'}
+        """
+        url = f"{self.base_url}/services/{service_id}"
+        params = {"server": server}
+        try:
+            response = self.session.put(url, json=data, params=params)
+            response.raise_for_status()
+            return response.json()
+        except HTTPError as e:
+            try:
+                error_detail = response.json().get("detail", str(e))
+            except Exception:
+                error_detail = str(e)
+
+            if "not found" in error_detail.lower():
+                raise ValueError("Error updating service: Not found")
+            elif "Reserved key" in error_detail:
+                raise ValueError(f"Error updating service: {error_detail}")
+            else:
+                raise ValueError(f"Error updating service: {error_detail}")
+
+    def patch_service(
+        self, service_id: str, data: Dict[str, Any], server: str = "local"
+    ) -> Dict[str, Any]:
+        """
+        Partially update an existing service by making a PATCH request.
+
+        Only updates the fields provided in data, leaving other fields
+        unchanged. This is useful when you only want to modify specific
+        attributes without affecting the rest of the service.
+
+        Args:
+            service_id: ID of the service to update.
+            data: Partial data for updating the service. Can contain:
+                - service_name: Optional unique name of the service
+                - service_title: Optional title of the service
+                - owner_org: Optional ID of the organization
+                - service_url: Optional URL where service is accessible
+                - service_type: Optional type (API, Web Service, etc.)
+                - notes: Optional additional notes
+                - extras: Optional additional metadata (merged with existing)
+                - health_check_url: Optional health check endpoint
+                - documentation_url: Optional documentation URL
+            server: Specify 'local' or 'pre_ckan'. Defaults to 'local'.
+
+        Returns:
+            Response JSON data indicating success.
+
+        Raises:
+            ValueError: If the update fails.
+
+        Example:
+            >>> client.patch_service(
+            ...     "service-id-123",
+            ...     {"service_url": "https://new-url.example.com/api"}
+            ... )
+            {'message': 'Service updated successfully'}
+        """
+        url = f"{self.base_url}/services/{service_id}"
+        params = {"server": server}
+        try:
+            response = self.session.patch(url, json=data, params=params)
+            response.raise_for_status()
+            return response.json()
+        except HTTPError as e:
+            try:
+                error_detail = response.json().get("detail", str(e))
+            except Exception:
+                error_detail = str(e)
+
+            if "not found" in error_detail.lower():
+                raise ValueError("Error updating service: Not found")
+            elif "Reserved key" in error_detail:
+                raise ValueError(f"Error updating service: {error_detail}")
+            else:
+                raise ValueError(f"Error updating service: {error_detail}")

--- a/tests/test_additional_methods.py
+++ b/tests/test_additional_methods.py
@@ -11,6 +11,7 @@ from ndp_ep.list_organization_method import APIClientOrganizationList
 from ndp_ep.update_dataset_method import APIClientDatasetUpdate
 from ndp_ep.update_kafka_method import APIClientKafkaUpdate
 from ndp_ep.update_s3_method import APIClientS3Update
+from ndp_ep.update_service_method import APIClientServiceUpdate
 from ndp_ep.update_url_method import APIClientURLUpdate
 
 
@@ -136,6 +137,13 @@ class TestUpdateMethods:
             return APIClientURLUpdate(base_url="http://example.com")
 
     @pytest.fixture
+    def update_service_client(self):
+        """Create update service client."""
+        with requests_mock.Mocker() as m:
+            m.get("http://example.com", status_code=200)
+            return APIClientServiceUpdate(base_url="http://example.com")
+
+    @pytest.fixture
     def update_dataset_client(self):
         """Create update dataset client."""
         with requests_mock.Mocker() as m:
@@ -213,6 +221,76 @@ class TestUpdateMethods:
 
             with pytest.raises(ValueError, match="Reserved key"):
                 update_s3_client.patch_s3_resource("s3123", patch_data)
+
+    def test_update_service_success(self, update_service_client):
+        """Test successful service update."""
+        update_data = {"service_title": "Updated Service"}
+
+        with requests_mock.Mocker() as m:
+            m.put(
+                "http://example.com/services/svc123",
+                json={"message": "Service updated successfully"},
+                status_code=200,
+            )
+
+            result = update_service_client.update_service("svc123", update_data)
+            assert "updated successfully" in result["message"]
+
+    def test_update_service_not_found(self, update_service_client):
+        """Test service update when not found."""
+        update_data = {"service_title": "New Title"}
+
+        with requests_mock.Mocker() as m:
+            m.put(
+                "http://example.com/services/nonexistent",
+                json={"detail": "Service not found"},
+                status_code=404,
+            )
+
+            with pytest.raises(ValueError, match="Not found"):
+                update_service_client.update_service("nonexistent", update_data)
+
+    def test_patch_service_success(self, update_service_client):
+        """Test successful service partial update."""
+        patch_data = {"service_url": "https://new-url.example.com/api"}
+
+        with requests_mock.Mocker() as m:
+            m.patch(
+                "http://example.com/services/svc123",
+                json={"message": "Service updated successfully"},
+                status_code=200,
+            )
+
+            result = update_service_client.patch_service("svc123", patch_data)
+            assert "updated successfully" in result["message"]
+
+    def test_patch_service_not_found(self, update_service_client):
+        """Test service partial update when not found."""
+        patch_data = {"service_title": "New Title"}
+
+        with requests_mock.Mocker() as m:
+            m.patch(
+                "http://example.com/services/nonexistent",
+                json={"detail": "Service not found"},
+                status_code=404,
+            )
+
+            with pytest.raises(ValueError, match="Not found"):
+                update_service_client.patch_service("nonexistent", patch_data)
+
+    def test_patch_service_reserved_key(self, update_service_client):
+        """Test service partial update with reserved key error."""
+        patch_data = {"extras": {"id": "reserved"}}
+
+        with requests_mock.Mocker() as m:
+            m.patch(
+                "http://example.com/services/svc123",
+                json={"detail": "Reserved key error: id"},
+                status_code=400,
+            )
+
+            with pytest.raises(ValueError, match="Reserved key"):
+                update_service_client.patch_service("svc123", patch_data)
 
     def test_update_url_resource_success(self, update_url_client):
         """Test successful URL resource update."""


### PR DESCRIPTION
## Summary
- Add `update_service()` for full service updates (PUT /services/{service_id})
- Add `patch_service()` for partial updates (PATCH /services/{service_id})
- Handle not found and reserved key errors

## Test plan
- [x] Unit tests pass (5 new tests)
- [x] All tests pass (145 total)
- [x] flake8, mypy checks pass
- [x] Coverage at 88%

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)