### PR TITLE
new remote execution semantic support

### DIFF
--- a/ndp_ep/rexec_method.py
+++ b/ndp_ep/rexec_method.py
@@ -61,7 +61,9 @@ class APIClientRexec(APIClientBase):
 
         requirements_path, cleanup = self._prepare_requirements(requirements)
         try:
-            remote_func.set_environment(
+            # POST to spawn api endpoint to deploy server
+            # Save resolved_token to remote_func.exec_token
+            resp = remote_func.set_environment(
                 str(requirements_path),
                 resolved_token,
             )
@@ -72,7 +74,7 @@ class APIClientRexec(APIClientBase):
         self._configure_remote_func(
             remote_func, broker_config, default_api_url=rexec_url
         )
-        return broker_config
+        return resp
 
     def _require_remote_func(self) -> Any:
         if (

--- a/ndp_ep/rexec_method.py
+++ b/ndp_ep/rexec_method.py
@@ -74,7 +74,7 @@ class APIClientRexec(APIClientBase):
         self._configure_remote_func(
             remote_func, broker_config, default_api_url=rexec_url
         )
-        return resp
+        return resp.json()
 
     def _require_remote_func(self) -> Any:
         if (


### PR DESCRIPTION
https://github.com/sci-ndp/ndp-ep-py/blob/3e4258fa8e1d2936bae3b51c9a53c4e340bcc48d/ndp_ep/rexec_method.py#L22

To support the newly updated remote execution semantics ( prompt user more information when they trigger spawn server ), I changed the return for the function shown above.

the expected behavior should be like this:
<img width="619" height="415" alt="Screenshot 2026-03-12 at 9 29 55 PM" src="https://github.com/user-attachments/assets/56f9ecb8-36ca-4267-8abc-34521b527209" />

changes are only in ./ndp-ep/rexec-method.py, this PR will not affect the rest of the library. Please review, thanks @rbardaji @saleemalharir1 